### PR TITLE
Persist active ids on page reload

### DIFF
--- a/app/components/shared/ActivatePanel.tsx
+++ b/app/components/shared/ActivatePanel.tsx
@@ -13,10 +13,10 @@ type ActivatePanelProps = {
 export default function ActivatePanel({ 
     targetPanelId, children 
 }: ActivatePanelProps) {
-    const { setPanelForActivation } = usePanelActivationContext();
+    const { setMainTargetId } = usePanelActivationContext();
 
     const handleClick = () => {
-        setPanelForActivation(targetPanelId);
+        setMainTargetId(targetPanelId);
     };
 
     return (

--- a/app/components/shared/PanelGroup.tsx
+++ b/app/components/shared/PanelGroup.tsx
@@ -45,7 +45,8 @@ function PanelGroup({
     const [currentActiveId, setCurrentActiveId] = useState(activeId);
 
     const {
-        setPanelForActivation,
+        activatePanel,
+        deactivatePanel
     } = usePanelActivationContext();
 
     const {
@@ -55,22 +56,21 @@ function PanelGroup({
 
     const handleSelectPanel = (event: ChangeEvent<HTMLSelectElement>) => {
         setCurrentActiveId(event.target.value);
-        setPanelForActivation(event.target.value);
+        activatePanel(event.target.value);
+        deactivatePanel(currentActiveId)
     }
 
     const togglePanelGroup = () => {
         setIsOpen(prevState => !prevState);
     }
-    
-    useEffect(() => {
-        setPanelForActivation(currentActiveId);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
 
     useEffect(() => {
         if (activePanelId) {
             setCurrentActiveId(activePanelId);
+        } else {
+            activatePanel(activeId);
         }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activePanelId]);
 
     return (

--- a/app/contexts/PanelGroupContext.tsx
+++ b/app/contexts/PanelGroupContext.tsx
@@ -25,9 +25,12 @@ export function PanelGroupContextProvider({
     const [activePanelId, setActivePanelId] = useState<string | null>(null);
 
     const { 
-        readyToBeActiveIds,
-        activatePanel, 
-    } = usePanelActivationContext();
+        activeIds,
+        targetIdFromMain,
+        activatePanel,
+        deactivatePanel,
+        setMainTargetId,
+     } = usePanelActivationContext();
 
     const registerNewPanel = (id: string) => {
         setPanelIdSet(prevSet => prevSet.add(id));
@@ -41,14 +44,25 @@ export function PanelGroupContextProvider({
     }
 
     useEffect(() => {
-        readyToBeActiveIds.forEach(id => {
+        activeIds.forEach(id => {
             if (panelIdSet.has(id)) {
                 setActivePanelId(id);
-                activatePanel(id);
             }
         });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [readyToBeActiveIds]);
+    }, [activeIds]);
+
+    useEffect(() => {
+        if (targetIdFromMain && panelIdSet.has(targetIdFromMain)) {
+            setActivePanelId(targetIdFromMain);
+            activatePanel(targetIdFromMain);
+            if (activePanelId) {
+                deactivatePanel(activePanelId);
+            }
+            setMainTargetId(null);
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [targetIdFromMain, activePanelId])
 
     return (
         <PanelGroupContext.Provider

--- a/app/utils/usePersist.ts
+++ b/app/utils/usePersist.ts
@@ -1,0 +1,32 @@
+import { useLocation, useSearchParams, useSubmit } from "@remix-run/react";
+import { useEffect, useState } from "react";
+
+export function usePersist() {
+    const [persistedValues, setPersistedValues] = useState<string[]>([]);
+
+    const submit = useSubmit();
+    const location = useLocation();
+    const [searchParams] = useSearchParams();
+
+    const persistValues = (values: string[]) => {
+        let formData = new FormData();
+        values.forEach((value) => {
+            formData.append(value, 'active');
+        })
+        submit(formData, {
+            method: 'get',
+            action: location.pathname,
+            replace: true,
+        });
+    }
+
+    useEffect(() => {
+        setPersistedValues(Array.from(searchParams.keys()));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    return {
+        persistedValues,
+        persistValues
+    }
+}


### PR DESCRIPTION
- Create usePersist hook to persist values by passing ids as query params.
- Update PanelActivationContext to handle persisted values and store target id from main content. Include utility functions for direct activation and deactivation of panels.
- Update PanelGroupContext to handle activation of target id from main content. 
